### PR TITLE
chore: remove async

### DIFF
--- a/src/types/user_operation.rs
+++ b/src/types/user_operation.rs
@@ -57,7 +57,7 @@ impl UserOperation {
         Bytes::from(packed)
     }
 
-    pub fn hash(&self, entry_point_address: Address, chain_id: U256) -> UserOperationHash {
+    pub fn hash(&self, entry_point_address: &Address, chain_id: &U256) -> UserOperationHash {
         H256::from_slice(
             keccak256(
                 [
@@ -209,20 +209,20 @@ mod tests {
         ];
         assert_eq!(
             user_operations[0].hash(
-                "0x2DF1592238420ecFe7f2431360e224707e77fA0E"
+                &"0x2DF1592238420ecFe7f2431360e224707e77fA0E"
                     .parse()
                     .unwrap(),
-                U256::from(1)
+                &U256::from(1)
             ),
             H256::from_str("0x42e145138104ec4124367ea3f7994833071b2011927290f6844d593e05011279")
                 .unwrap()
         );
         assert_eq!(
             user_operations[1].hash(
-                "0x2DF1592238420ecFe7f2431360e224707e77fA0E"
+                &"0x2DF1592238420ecFe7f2431360e224707e77fA0E"
                     .parse()
                     .unwrap(),
-                U256::from(1)
+                &U256::from(1)
             ),
             H256::from_str("0x583c8fcba470fd9da514f9482ccd31c299b0161a36b365aab353a6bfebaa0bb2")
                 .unwrap()

--- a/src/uopool/memory_reputation.rs
+++ b/src/uopool/memory_reputation.rs
@@ -1,11 +1,7 @@
 use async_trait::async_trait;
 use educe::Educe;
 use ethers::types::{Address, U256};
-use parking_lot::RwLock;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
 use crate::types::reputation::{
     BadReputationError, ReputationEntry, ReputationError, ReputationStatus, StakeInfo,
@@ -22,9 +18,24 @@ pub struct MemoryReputation {
     min_stake: U256,
     min_unstake_delay: U256,
 
-    entities: Arc<RwLock<HashMap<Address, ReputationEntry>>>,
-    whitelist: Arc<RwLock<HashSet<Address>>>,
-    blacklist: Arc<RwLock<HashSet<Address>>>,
+    entities: HashMap<Address, ReputationEntry>,
+    whitelist: HashSet<Address>,
+    blacklist: HashSet<Address>,
+}
+
+impl MemoryReputation {
+    fn set(&mut self, address: &Address) {
+        if !self.entities.contains_key(address) {
+            let entity = ReputationEntry {
+                address: *address,
+                uo_seen: 0,
+                uo_included: 0,
+                status: ReputationStatus::OK,
+            };
+
+            self.entities.insert(*address, entity);
+        }
+    }
 }
 
 #[async_trait]
@@ -46,11 +57,9 @@ impl Reputation for MemoryReputation {
         self.min_unstake_delay = min_unstake_delay;
     }
 
-    async fn get(&mut self, address: &Address) -> anyhow::Result<ReputationEntry> {
-        let mut entities = self.entities.write();
-
-        if let Some(entity) = entities.get(address) {
-            return Ok(*entity);
+    fn get(&mut self, address: &Address) -> ReputationEntry {
+        if let Some(entity) = self.entities.get(address) {
+            return *entity;
         }
 
         let entity = ReputationEntry {
@@ -60,112 +69,97 @@ impl Reputation for MemoryReputation {
             status: ReputationStatus::OK,
         };
 
-        entities.insert(*address, entity);
+        self.entities.insert(*address, entity);
 
-        Ok(entity)
+        entity
     }
 
-    async fn increment_seen(&mut self, address: &Address) -> anyhow::Result<()> {
-        let mut entities = self.entities.write();
-
-        if let Some(entity) = entities.get_mut(address) {
+    fn increment_seen(&mut self, address: &Address) {
+        self.set(address);
+        if let Some(entity) = self.entities.get_mut(address) {
             entity.uo_seen += 1;
-            return Ok(());
         }
-
-        Err(anyhow::anyhow!("Entity not found"))
     }
 
-    async fn increment_included(&mut self, address: &Address) -> anyhow::Result<()> {
-        let mut entities = self.entities.write();
-
-        if let Some(entity) = entities.get_mut(address) {
+    fn increment_included(&mut self, address: &Address) {
+        self.set(address);
+        if let Some(entity) = self.entities.get_mut(address) {
             entity.uo_included += 1;
-            return Ok(());
         }
-
-        Err(anyhow::anyhow!("Entity not found"))
     }
 
     fn update_hourly(&mut self) {
-        let mut entities = self.entities.write();
-        for (_, entity) in entities.iter_mut() {
+        for (_, entity) in self.entities.iter_mut() {
             entity.uo_seen = entity.uo_seen * 23 / 24;
             entity.uo_included = entity.uo_included * 23 / 24;
         }
-        entities.retain(|_, entity| entity.uo_seen > 0 || entity.uo_included > 0);
+        self.entities
+            .retain(|_, entity| entity.uo_seen > 0 || entity.uo_included > 0);
     }
 
-    async fn add_whitelist(&mut self, address: &Address) -> anyhow::Result<()> {
-        self.whitelist.write().insert(*address);
-        Ok(())
+    fn add_whitelist(&mut self, address: &Address) -> bool {
+        self.whitelist.insert(*address)
     }
 
-    async fn remove_whitelist(&mut self, address: &Address) -> anyhow::Result<bool> {
-        Ok(self.whitelist.write().remove(address))
+    fn remove_whitelist(&mut self, address: &Address) -> bool {
+        self.whitelist.remove(address)
     }
 
-    async fn is_whitelist(&self, address: &Address) -> anyhow::Result<bool> {
-        Ok(self.whitelist.read().contains(address))
+    fn is_whitelist(&self, address: &Address) -> bool {
+        self.whitelist.contains(address)
     }
 
-    async fn add_blacklist(&mut self, address: &Address) -> anyhow::Result<()> {
-        self.blacklist.write().insert(*address);
-        Ok(())
+    fn add_blacklist(&mut self, address: &Address) -> bool {
+        self.blacklist.insert(*address)
     }
 
-    async fn remove_blacklist(&mut self, address: &Address) -> anyhow::Result<bool> {
-        Ok(self.blacklist.write().remove(address))
+    fn remove_blacklist(&mut self, address: &Address) -> bool {
+        self.blacklist.remove(address)
     }
 
-    async fn is_blacklist(&self, address: &Address) -> anyhow::Result<bool> {
-        Ok(self.blacklist.read().contains(address))
+    fn is_blacklist(&self, address: &Address) -> bool {
+        self.blacklist.contains(address)
     }
 
-    async fn get_status(&self, address: &Address) -> anyhow::Result<ReputationStatus> {
-        if self.is_whitelist(address).await? {
-            return Ok(ReputationStatus::OK);
+    fn get_status(&self, address: &Address) -> ReputationStatus {
+        if self.is_whitelist(address) {
+            return ReputationStatus::OK;
         }
 
-        if self.is_blacklist(address).await? {
-            return Ok(ReputationStatus::BANNED);
+        if self.is_blacklist(address) {
+            return ReputationStatus::BANNED;
         }
 
-        let entities = self.entities.read();
-
-        match entities.get(address) {
+        match self.entities.get(address) {
             Some(entity) => {
                 let min_expected_included = entity.uo_seen / self.min_inclusion_denominator;
                 if min_expected_included <= entity.uo_included + self.throttling_slack {
-                    Ok(ReputationStatus::OK)
+                    ReputationStatus::OK
                 } else if min_expected_included <= entity.uo_included + self.ban_slack {
-                    Ok(ReputationStatus::THROTTLED)
+                    ReputationStatus::THROTTLED
                 } else {
-                    Ok(ReputationStatus::BANNED)
+                    ReputationStatus::BANNED
                 }
             }
-            _ => Ok(ReputationStatus::OK),
+            _ => ReputationStatus::OK,
         }
     }
 
-    async fn update_handle_ops_reverted(&mut self, address: &Address) -> anyhow::Result<()> {
-        if let Ok(mut entity) = self.get(address).await {
+    fn update_handle_ops_reverted(&mut self, address: &Address) {
+        self.set(address);
+        if let Some(entity) = self.entities.get_mut(address) {
             entity.uo_seen = 100;
             entity.uo_included = 0;
         }
-
-        Ok(())
     }
 
-    async fn verify_stake(&self, title: &str, stake_info: Option<StakeInfo>) -> anyhow::Result<()> {
+    fn verify_stake(&self, title: &str, stake_info: Option<StakeInfo>) -> anyhow::Result<()> {
         if let Some(stake_info) = stake_info {
-            if self.is_whitelist(&stake_info.address).await? {
+            if self.is_whitelist(&stake_info.address) {
                 return Ok(());
             }
 
-            let entities = self.entities.read();
-
-            if let Some(entity) = entities.get(&stake_info.address) {
+            if let Some(entity) = self.entities.get(&stake_info.address) {
                 let error = if entity.status == ReputationStatus::BANNED {
                     BadReputationError::EntityBanned {
                         address: stake_info.address,
@@ -202,21 +196,19 @@ impl Reputation for MemoryReputation {
 
     #[cfg(debug_assertions)]
     fn set(&mut self, reputation_entries: Self::ReputationEntries) {
-        let mut entities = self.entities.write();
-
         for reputation in reputation_entries {
-            entities.insert(reputation.address, reputation);
+            self.entities.insert(reputation.address, reputation);
         }
     }
 
     #[cfg(debug_assertions)]
     fn get_all(&self) -> Self::ReputationEntries {
-        self.entities.read().values().cloned().collect()
+        self.entities.values().cloned().collect()
     }
 
     #[cfg(debug_assertions)]
     fn clear(&mut self) {
-        self.entities.write().clear();
+        self.entities.clear();
     }
 }
 
@@ -242,7 +234,7 @@ mod tests {
         for _ in 0..5 {
             let address = Address::random();
             assert_eq!(
-                reputation.get(&address).await.unwrap(),
+                reputation.get(&address),
                 ReputationEntry {
                     address,
                     uo_seen: 0,
@@ -253,86 +245,53 @@ mod tests {
             addresses.push(address);
         }
 
-        assert_eq!(reputation.add_whitelist(&addresses[2]).await.unwrap(), ());
-        assert_eq!(reputation.add_blacklist(&addresses[1]).await.unwrap(), ());
+        assert_eq!(reputation.add_whitelist(&addresses[2]), true);
+        assert_eq!(reputation.add_blacklist(&addresses[1]), true);
 
-        assert_eq!(reputation.is_whitelist(&addresses[2]).await.unwrap(), true);
-        assert_eq!(reputation.is_whitelist(&addresses[1]).await.unwrap(), false);
-        assert_eq!(reputation.is_blacklist(&addresses[1]).await.unwrap(), true);
-        assert_eq!(reputation.is_blacklist(&addresses[2]).await.unwrap(), false);
+        assert_eq!(reputation.is_whitelist(&addresses[2]), true);
+        assert_eq!(reputation.is_whitelist(&addresses[1]), false);
+        assert_eq!(reputation.is_blacklist(&addresses[1]), true);
+        assert_eq!(reputation.is_blacklist(&addresses[2]), false);
 
-        assert_eq!(
-            reputation.remove_whitelist(&addresses[2]).await.unwrap(),
-            true
-        );
-        assert_eq!(
-            reputation.remove_whitelist(&addresses[1]).await.unwrap(),
-            false
-        );
-        assert_eq!(
-            reputation.remove_blacklist(&addresses[1]).await.unwrap(),
-            true
-        );
-        assert_eq!(
-            reputation.remove_blacklist(&addresses[2]).await.unwrap(),
-            false
-        );
+        assert_eq!(reputation.remove_whitelist(&addresses[2]), true);
+        assert_eq!(reputation.remove_whitelist(&addresses[1]), false);
+        assert_eq!(reputation.remove_blacklist(&addresses[1]), true);
+        assert_eq!(reputation.remove_blacklist(&addresses[2]), false);
 
-        assert_eq!(reputation.add_whitelist(&addresses[2]).await.unwrap(), ());
-        assert_eq!(reputation.add_blacklist(&addresses[1]).await.unwrap(), ());
+        assert_eq!(reputation.add_whitelist(&addresses[2]), true);
+        assert_eq!(reputation.add_blacklist(&addresses[1]), true);
 
+        assert_eq!(reputation.get_status(&addresses[2]), ReputationStatus::OK);
         assert_eq!(
-            reputation.get_status(&addresses[2]).await.unwrap(),
-            ReputationStatus::OK
-        );
-        assert_eq!(
-            reputation.get_status(&addresses[1]).await.unwrap(),
+            reputation.get_status(&addresses[1]),
             ReputationStatus::BANNED
         );
-        assert_eq!(
-            reputation.get_status(&addresses[3]).await.unwrap(),
-            ReputationStatus::OK
-        );
+        assert_eq!(reputation.get_status(&addresses[3]), ReputationStatus::OK);
 
-        assert_eq!(reputation.increment_seen(&addresses[2]).await.unwrap(), ());
-        assert_eq!(reputation.increment_seen(&addresses[2]).await.unwrap(), ());
-        assert_eq!(reputation.increment_seen(&addresses[3]).await.unwrap(), ());
-        assert_eq!(reputation.increment_seen(&addresses[3]).await.unwrap(), ());
+        assert_eq!(reputation.increment_seen(&addresses[2]), ());
+        assert_eq!(reputation.increment_seen(&addresses[2]), ());
+        assert_eq!(reputation.increment_seen(&addresses[3]), ());
+        assert_eq!(reputation.increment_seen(&addresses[3]), ());
 
-        assert_eq!(
-            reputation.increment_included(&addresses[2]).await.unwrap(),
-            ()
-        );
-        assert_eq!(
-            reputation.increment_included(&addresses[2]).await.unwrap(),
-            ()
-        );
-        assert_eq!(
-            reputation.increment_included(&addresses[3]).await.unwrap(),
-            ()
-        );
+        assert_eq!(reputation.increment_included(&addresses[2]), ());
+        assert_eq!(reputation.increment_included(&addresses[2]), ());
+        assert_eq!(reputation.increment_included(&addresses[3]), ());
 
-        assert_eq!(
-            reputation
-                .update_handle_ops_reverted(&addresses[3])
-                .await
-                .unwrap(),
-            ()
-        );
+        assert_eq!(reputation.update_handle_ops_reverted(&addresses[3]), ());
 
         for _ in 0..250 {
-            assert_eq!(reputation.increment_seen(&addresses[3]).await.unwrap(), ());
+            assert_eq!(reputation.increment_seen(&addresses[3]), ());
         }
         assert_eq!(
-            reputation.get_status(&addresses[3]).await.unwrap(),
+            reputation.get_status(&addresses[3]),
             ReputationStatus::THROTTLED
         );
 
         for _ in 0..500 {
-            assert_eq!(reputation.increment_seen(&addresses[3]).await.unwrap(), ());
+            assert_eq!(reputation.increment_seen(&addresses[3]), ());
         }
         assert_eq!(
-            reputation.get_status(&addresses[3]).await.unwrap(),
+            reputation.get_status(&addresses[3]),
             ReputationStatus::BANNED
         );
     }

--- a/src/uopool/mod.rs
+++ b/src/uopool/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     utils::parse_u256,
 };
 use anyhow::Result;
-use async_trait::async_trait;
 use clap::Parser;
 use educe::Educe;
 use ethers::{
@@ -32,26 +31,25 @@ pub mod services;
 
 pub type MempoolId = H256;
 
-pub type MempoolBox<T> = Box<dyn Mempool<UserOperations = T>>;
-pub type ReputationBox<T> = Box<dyn Reputation<ReputationEntries = T>>;
+pub type MempoolBox<T> = Box<dyn Mempool<UserOperations = T> + Send + Sync>;
+pub type ReputationBox<T> = Box<dyn Reputation<ReputationEntries = T> + Send + Sync>;
 
 pub fn mempool_id(entry_point: Address, chain_id: U256) -> MempoolId {
     H256::from_slice(keccak256([entry_point.encode(), chain_id.encode()].concat()).as_slice())
 }
 
-#[async_trait]
-pub trait Mempool: Debug + Send + Sync + 'static {
+pub trait Mempool: Debug {
     type UserOperations: IntoIterator<Item = UserOperation>;
 
-    async fn add(
+    fn add(
         &mut self,
         user_operation: UserOperation,
-        entry_point: Address,
-        chain_id: U256,
-    ) -> anyhow::Result<UserOperationHash>;
-    async fn get(&self, user_operation_hash: UserOperationHash) -> anyhow::Result<UserOperation>;
-    async fn get_all_by_sender(&self, sender: Address) -> anyhow::Result<Self::UserOperations>;
-    async fn remove(&mut self, user_operation_hash: UserOperationHash) -> anyhow::Result<()>;
+        entry_point: &Address,
+        chain_id: &U256,
+    ) -> UserOperationHash;
+    fn get(&self, user_operation_hash: &UserOperationHash) -> anyhow::Result<UserOperation>;
+    fn get_all_by_sender(&self, sender: &Address) -> Self::UserOperations;
+    fn remove(&mut self, user_operation_hash: &UserOperationHash) -> anyhow::Result<()>;
 
     #[cfg(debug_assertions)]
     fn get_all(&self) -> Self::UserOperations;
@@ -60,8 +58,7 @@ pub trait Mempool: Debug + Send + Sync + 'static {
     fn clear(&mut self);
 }
 
-#[async_trait]
-pub trait Reputation: Debug + Send + Sync + 'static {
+pub trait Reputation: Debug {
     type ReputationEntries: IntoIterator<Item = ReputationEntry>;
 
     fn init(
@@ -72,19 +69,19 @@ pub trait Reputation: Debug + Send + Sync + 'static {
         min_stake: U256,
         min_unstake_delay: U256,
     );
-    async fn get(&mut self, address: &Address) -> anyhow::Result<ReputationEntry>;
-    async fn increment_seen(&mut self, address: &Address) -> anyhow::Result<()>;
-    async fn increment_included(&mut self, address: &Address) -> anyhow::Result<()>;
+    fn get(&mut self, address: &Address) -> ReputationEntry;
+    fn increment_seen(&mut self, address: &Address);
+    fn increment_included(&mut self, address: &Address);
     fn update_hourly(&mut self);
-    async fn add_whitelist(&mut self, address: &Address) -> anyhow::Result<()>;
-    async fn remove_whitelist(&mut self, address: &Address) -> anyhow::Result<bool>;
-    async fn is_whitelist(&self, address: &Address) -> anyhow::Result<bool>;
-    async fn add_blacklist(&mut self, address: &Address) -> anyhow::Result<()>;
-    async fn remove_blacklist(&mut self, address: &Address) -> anyhow::Result<bool>;
-    async fn is_blacklist(&self, address: &Address) -> anyhow::Result<bool>;
-    async fn get_status(&self, address: &Address) -> anyhow::Result<ReputationStatus>;
-    async fn update_handle_ops_reverted(&mut self, address: &Address) -> anyhow::Result<()>;
-    async fn verify_stake(&self, title: &str, stake_info: Option<StakeInfo>) -> anyhow::Result<()>;
+    fn add_whitelist(&mut self, address: &Address) -> bool;
+    fn remove_whitelist(&mut self, address: &Address) -> bool;
+    fn is_whitelist(&self, address: &Address) -> bool;
+    fn add_blacklist(&mut self, address: &Address) -> bool;
+    fn remove_blacklist(&mut self, address: &Address) -> bool;
+    fn is_blacklist(&self, address: &Address) -> bool;
+    fn get_status(&self, address: &Address) -> ReputationStatus;
+    fn update_handle_ops_reverted(&mut self, address: &Address);
+    fn verify_stake(&self, title: &str, stake_info: Option<StakeInfo>) -> anyhow::Result<()>;
 
     #[cfg(debug_assertions)]
     fn set(&mut self, reputation_entries: Self::ReputationEntries);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -103,8 +103,8 @@ pub async fn deploy_test_rules_account_factory<M: Middleware + 'static>(
 
 pub async fn sign(
     user_op: &mut UserOperation,
-    entry_point_address: Address,
-    chain_id: U256,
+    entry_point_address: &Address,
+    chain_id: &U256,
     key: Wallet<SigningKey>,
 ) -> anyhow::Result<()> {
     let user_op_hash = user_op.hash(entry_point_address, chain_id);


### PR DESCRIPTION
There is a `RwLock` for mempools and reputations on the UoPoolService level (`Arc<RwLock<HashMap<MempoolId...`), and both will always be accessed over these two hashmaps, thus we don't need async traits for Mempool and Reputation.