### PR TITLE
Send bundles from aa-bundler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	cargo build
 
 run-bundler:
-	cargo run -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.aa-bundler/0x129D197b2a989C6798601A49D89a4AEC822A17a3 --beneficiary 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990 --gas-factor 600 --min-balance 1 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --helper 0x0000000000000000000000000000000000000000 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000 --chain-id 1337
+	cargo run -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.aa-bundler/0x129D197b2a989C6798601A49D89a4AEC822A17a3 --beneficiary 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990 --gas-factor 600 --min-balance 1 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --helper 0x0000000000000000000000000000000000000000 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000
 
 run-bundler-uopool:
 	cargo run --bin bundler-uopool -- --eth-client-address http://127.0.0.1:8545 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	cargo build
 
 run-bundler:
-	cargo run -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.aa-bundler/0x129D197b2a989C6798601A49D89a4AEC822A17a3 --beneficiary 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990 --gas-factor 600 --min-balance 1 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --helper 0x0000000000000000000000000000000000000000 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000
+	cargo run -- --eth-client-address http://127.0.0.1:8545 --mnemonic-file ${HOME}/.aa-bundler/0x129D197b2a989C6798601A49D89a4AEC822A17a3 --beneficiary 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990 --gas-factor 600 --min-balance 1 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --helper 0x0000000000000000000000000000000000000000 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000 --chain-id 1337
 
 run-bundler-uopool:
 	cargo run --bin bundler-uopool -- --eth-client-address http://127.0.0.1:8545 --entry-points 0x0576a174D229E3cFA37253523E645A78A0C91B57 --min-stake 1 --min-unstake-delay 0 --min-priority-fee-per-gas 0 --max-verification-gas 1500000

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -79,6 +79,9 @@ fn main() -> Result<()> {
 
                 let chain_id = eth_provider.get_chainid().await?;
 
+                let wallet = Wallet::from_file(opt.mnemonic_file.clone(), chain_id)?;
+                info!("{:?}", wallet.signer);
+
                 let eth_provider =
                     Arc::new(Provider::<Http>::try_from(opt.eth_client_address.clone())?);
 
@@ -88,10 +91,8 @@ fn main() -> Result<()> {
                 ))
                 .await?;
                 for entry_point in opt.entry_points.iter() {
-                    let wallet = Wallet::from_file(opt.mnemonic_file.clone(), chain_id)?;
-                    info!("{:?}", wallet.signer);
                     let _bundler = Bundler::new(
-                        wallet,
+                        &wallet,
                         opt.bundler_opts.beneficiary,
                         uopool_grpc_client.clone(),
                         opt.bundler_opts.bundle_interval,

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -92,10 +92,13 @@ fn main() -> Result<()> {
                     info!("{:?}", wallet.signer);
                     let _bundler = Bundler::new(
                         wallet,
+                        opt.bundler_opts.beneficiary,
                         uopool_grpc_client.clone(),
                         opt.bundler_opts.bundle_interval,
                         opt.bundler_opts.max_bundle_limit,
                         *entry_point,
+                        opt.eth_client_address.clone(),
+                        opt.bundler_opts.chain_id,
                     );
                 }
 

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -95,7 +95,6 @@ fn main() -> Result<()> {
                         opt.bundler_opts.beneficiary,
                         uopool_grpc_client.clone(),
                         opt.bundler_opts.bundle_interval,
-                        opt.bundler_opts.max_bundle_limit,
                         *entry_point,
                         opt.eth_client_address.clone(),
                         opt.bundler_opts.chain_id,

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -130,8 +130,7 @@ fn main() -> Result<()> {
 
                             let _jsonrpc_server_handle = jsonrpc_server.start(api.clone())?;
                             info!("JSON-RPC server listening on {}", opt.rpc_listen_address);
-
-                            pending::<Result<()>>().await
+                            <Result<(), anyhow::Error>>::Ok(())
                         }
                     });
                 }

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -97,7 +97,6 @@ fn main() -> Result<()> {
                         opt.bundler_opts.bundle_interval,
                         *entry_point,
                         opt.eth_client_address.clone(),
-                        opt.bundler_opts.chain_id,
                     );
                 }
 

--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -88,6 +88,7 @@ fn main() -> Result<()> {
                 let _bundler = Bundler::new(wallet);
 
                 if !opt.no_uopool {
+                    info!("Starting op pool with bundler");
                     aa_bundler::uopool::run(
                         opt.uopool_opts,
                         opt.entry_points,
@@ -98,6 +99,7 @@ fn main() -> Result<()> {
                 }
 
                 if !opt.no_rpc {
+                    info!("Starting rpc server with bundler");
                     tokio::spawn({
                         async move {
                             let jsonrpc_server = ServerBuilder::default()

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -124,8 +124,6 @@ impl<'a> Bundler<'a> {
         let res = client.send_transaction(tx, None).await?.await?;
 
         debug!("Send bundles with ret: {res:?}");
-
-        // TODO update reputation based on the execution result
         Ok(())
     }
 }

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -44,7 +44,7 @@ pub struct Bundler<'a> {
     pub beneficiary: Address,
     pub uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
     pub bundle_interval: u64,
-    pub entrypoint: Address,
+    pub entry_point: Address,
     pub eth_client_address: String,
 }
 
@@ -54,7 +54,7 @@ impl<'a> Bundler<'a> {
         beneficiary: Address,
         uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
         bundle_interval: u64,
-        entrypoint: Address,
+        entry_point: Address,
         eth_client_address: String,
     ) -> Self {
         Self {
@@ -62,7 +62,7 @@ impl<'a> Bundler<'a> {
             beneficiary,
             uopool_grpc_client,
             bundle_interval,
-            entrypoint,
+            entry_point,
             eth_client_address,
         }
     }
@@ -78,7 +78,7 @@ impl<'a> Bundler<'a> {
 
     async fn create_bundle(&mut self) -> anyhow::Result<Vec<UserOperation>> {
         let request = tonic::Request::new(GetSortedRequest {
-            entrypoint: Some(self.entrypoint.into()),
+            entry_point: Some(self.entry_point.into()),
         });
         let response = self
             .uopool_grpc_client
@@ -97,7 +97,7 @@ impl<'a> Bundler<'a> {
         let bundles = self.create_bundle().await?;
         let provider = Provider::<Http>::try_from(self.eth_client_address.clone())?;
         let client = Arc::new(SignerMiddleware::new(provider, self.wallet.signer.clone()));
-        let entry_point = EntryPointAPI::new(self.entrypoint, client.clone());
+        let entry_point = EntryPointAPI::new(self.entry_point, client.clone());
         let nonce = client
             .clone()
             .get_transaction_count(self.wallet.signer.address(), None)

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -37,9 +37,6 @@ pub struct BundlerOpts {
 
     #[clap(long, default_value = "10")]
     pub bundle_interval: u64,
-
-    #[clap(long, default_value = "1")]
-    pub chain_id: u64,
 }
 
 pub struct Bundler {
@@ -49,7 +46,6 @@ pub struct Bundler {
     pub bundle_interval: u64,
     pub entrypoint: Address,
     pub eth_client_address: String,
-    pub chain_id: u64,
 }
 
 impl Bundler {
@@ -60,7 +56,6 @@ impl Bundler {
         bundle_interval: u64,
         entrypoint: Address,
         eth_client_address: String,
-        chain_id: u64,
     ) -> Self {
         Self {
             wallet,
@@ -69,7 +64,6 @@ impl Bundler {
             bundle_interval,
             entrypoint,
             eth_client_address,
-            chain_id,
         }
     }
 
@@ -102,10 +96,7 @@ impl Bundler {
     async fn send_next_bundle(&mut self) -> anyhow::Result<()> {
         let bundles = self.create_bundle().await?;
         let provider = Provider::<Http>::try_from(self.eth_client_address.clone())?;
-        let client = Arc::new(SignerMiddleware::new(
-            provider,
-            self.wallet.signer.clone().with_chain_id(self.chain_id),
-        ));
+        let client = Arc::new(SignerMiddleware::new(provider, self.wallet.signer.clone()));
         let entry_point = EntryPointAPI::new(self.entrypoint, client.clone());
         let nonce = client
             .clone()
@@ -152,8 +143,6 @@ mod tests {
             "127.0.0.1:3002",
             "--bundle-interval",
             "10",
-            "--chain-id",
-            "1",
         ];
         assert_eq!(
             BundlerOpts {
@@ -164,7 +153,6 @@ mod tests {
                 helper: Address::from([0; 20]),
                 bundler_grpc_listen_address: String::from("127.0.0.1:3002"),
                 bundle_interval: 10,
-                chain_id: 1
             },
             BundlerOpts::try_parse_from(args).unwrap()
         );

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -39,8 +39,8 @@ pub struct BundlerOpts {
     pub bundle_interval: u64,
 }
 
-pub struct Bundler {
-    pub wallet: Wallet,
+pub struct Bundler<'a> {
+    pub wallet: &'a Wallet,
     pub beneficiary: Address,
     pub uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
     pub bundle_interval: u64,
@@ -48,9 +48,9 @@ pub struct Bundler {
     pub eth_client_address: String,
 }
 
-impl Bundler {
+impl<'a> Bundler<'a> {
     pub fn new(
-        wallet: Wallet,
+        wallet: &'a Wallet,
         beneficiary: Address,
         uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
         bundle_interval: u64,

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -1,10 +1,17 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use clap::Parser;
-use ethers::types::{Address, U256};
+use ethers::{
+    prelude::SignerMiddleware,
+    providers::{Http, Middleware, Provider},
+    signers::Signer,
+    types::{transaction::eip2718::TypedTransaction, Address, U256},
+};
 use tokio::time;
+use tracing::debug;
 
 use crate::{
+    contracts::gen::EntryPointAPI,
     models::wallet::Wallet,
     types::user_operation::UserOperation,
     uopool::server::uopool::{uo_pool_client::UoPoolClient, GetSortedRequest},
@@ -36,30 +43,45 @@ pub struct BundlerOpts {
 
     #[clap(long, value_parser=parse_address)]
     pub entrypoint: Address,
+
+    #[clap(long, default_value = "http://127.0.0.1:8545")]
+    pub eth_client_address: String,
+
+    #[clap(long, default_value = "1")]
+    pub chain_id: u64,
 }
 
 pub struct Bundler {
     pub wallet: Wallet,
+    pub beneficiary: Address,
     pub uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
     pub bundle_interval: u64,
     pub max_bundle_limit: u64,
     pub entrypoint: Address,
+    pub eth_client_address: String,
+    pub chain_id: u64,
 }
 
 impl Bundler {
     pub fn new(
         wallet: Wallet,
+        beneficiary: Address,
         uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
         bundle_interval: u64,
         max_bundle_limit: u64,
         entrypoint: Address,
+        eth_client_address: String,
+        chain_id: u64,
     ) -> Self {
         Self {
             wallet,
+            beneficiary,
             uopool_grpc_client,
             bundle_interval,
             max_bundle_limit,
             entrypoint,
+            eth_client_address,
+            chain_id,
         }
     }
 
@@ -91,8 +113,34 @@ impl Bundler {
     }
 
     async fn send_next_bundle(&mut self) -> anyhow::Result<()> {
-        let _bundles = self.create_bundle().await?;
-        todo!()
+        let bundles = self.create_bundle().await?;
+        let provider = Provider::<Http>::try_from(self.eth_client_address.clone())?;
+        let client = Arc::new(SignerMiddleware::new(
+            provider,
+            self.wallet.signer.clone().with_chain_id(self.chain_id),
+        ));
+        let entry_point = EntryPointAPI::new(self.entrypoint, client.clone());
+        let nonce = client
+            .clone()
+            .get_transaction_count(self.wallet.signer.address(), None)
+            .await?;
+        let fee = client.clone().estimate_eip1559_fees(None).await?;
+        let mut tx: TypedTransaction = entry_point
+            .handle_ops(
+                bundles.into_iter().map(Into::into).collect(),
+                self.beneficiary,
+            )
+            .tx
+            .clone();
+        tx.set_gas(U256::from(1000000))
+            .set_nonce(nonce)
+            .set_gas_price(fee.0);
+        let res = client.send_transaction(tx, None).await?.await?;
+
+        debug!("Send bundles with ret: {res:}");
+
+        // TODO check reputation on the task heres
+        Ok(())
     }
 }
 
@@ -121,6 +169,10 @@ mod tests {
             "10",
             "--entrypoint",
             "0x0000000000000000000000000000000000000000",
+            "--eth-client-address",
+            "http://127.0.0.1:8545",
+            "--chain-id",
+            "1",
         ];
         assert_eq!(
             BundlerOpts {
@@ -132,7 +184,9 @@ mod tests {
                 bundler_grpc_listen_address: String::from("127.0.0.1:3002"),
                 bundle_interval: 10,
                 max_bundle_limit: 10,
-                entrypoint: Address::from([0; 20])
+                entrypoint: Address::from([0; 20]),
+                eth_client_address: String::from("http://127.0.0.1:8545"),
+                chain_id: 1
             },
             BundlerOpts::try_parse_from(args).unwrap()
         );

--- a/src/bundler/mod.rs
+++ b/src/bundler/mod.rs
@@ -1,8 +1,13 @@
+use std::time::Duration;
+
 use clap::Parser;
 use ethers::types::{Address, U256};
+use tokio::time;
 
 use crate::{
     models::wallet::Wallet,
+    types::user_operation::UserOperation,
+    uopool::server::uopool::{uo_pool_client::UoPoolClient, GetSortedRequest},
     utils::{parse_address, parse_u256},
 };
 
@@ -22,15 +27,72 @@ pub struct BundlerOpts {
 
     #[clap(long, default_value = "127.0.0.1:3002")]
     pub bundler_grpc_listen_address: String,
+
+    #[clap(long, default_value = "10")]
+    pub bundle_interval: u64,
+
+    #[clap(long, default_value = "10")]
+    pub max_bundle_limit: u64,
+
+    #[clap(long, value_parser=parse_address)]
+    pub entrypoint: Address,
 }
 
 pub struct Bundler {
     pub wallet: Wallet,
+    pub uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
+    pub bundle_interval: u64,
+    pub max_bundle_limit: u64,
+    pub entrypoint: Address,
 }
 
 impl Bundler {
-    pub fn new(wallet: Wallet) -> Self {
-        Self { wallet }
+    pub fn new(
+        wallet: Wallet,
+        uopool_grpc_client: UoPoolClient<tonic::transport::Channel>,
+        bundle_interval: u64,
+        max_bundle_limit: u64,
+        entrypoint: Address,
+    ) -> Self {
+        Self {
+            wallet,
+            uopool_grpc_client,
+            bundle_interval,
+            max_bundle_limit,
+            entrypoint,
+        }
+    }
+
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        let mut interval = time::interval(Duration::from_secs(self.bundle_interval));
+
+        loop {
+            interval.tick().await;
+            self.send_next_bundle().await?;
+        }
+    }
+
+    async fn create_bundle(&mut self) -> anyhow::Result<Vec<UserOperation>> {
+        let request = tonic::Request::new(GetSortedRequest {
+            entrypoint: Some(self.entrypoint.into()),
+            max_limit: self.max_bundle_limit,
+        });
+        let response = self
+            .uopool_grpc_client
+            .get_sorted_user_operations(request)
+            .await?;
+        let user_operations: Vec<UserOperation> = response
+            .into_inner()
+            .user_operations
+            .into_iter()
+            .map(|u| u.into())
+            .collect();
+        Ok(user_operations)
+    }
+
+    async fn send_next_bundle(&mut self) -> anyhow::Result<()> {
+        let _bundles = self.create_bundle().await?;
+        todo!()
     }
 }
 
@@ -53,6 +115,12 @@ mod tests {
             "0x0000000000000000000000000000000000000000",
             "--bundler-grpc-listen-address",
             "127.0.0.1:3002",
+            "--bundle-interval",
+            "10",
+            "--max-bundle-limit",
+            "10",
+            "--entrypoint",
+            "0x0000000000000000000000000000000000000000",
         ];
         assert_eq!(
             BundlerOpts {
@@ -61,7 +129,10 @@ mod tests {
                 gas_factor: U256::from(600),
                 min_balance: U256::from(1),
                 helper: Address::from([0; 20]),
-                bundler_grpc_listen_address: String::from("127.0.0.1:3002")
+                bundler_grpc_listen_address: String::from("127.0.0.1:3002"),
+                bundle_interval: 10,
+                max_bundle_limit: 10,
+                entrypoint: Address::from([0; 20])
             },
             BundlerOpts::try_parse_from(args).unwrap()
         );

--- a/src/proto/uopool/uopool.proto
+++ b/src/proto/uopool/uopool.proto
@@ -109,7 +109,6 @@ message SetReputationResponse {
 
 message GetSortedRequest{
     types.H160 entrypoint = 1;
-    uint64 max_limit = 2;
 }
 
 message GetSortedResponse{

--- a/src/proto/uopool/uopool.proto
+++ b/src/proto/uopool/uopool.proto
@@ -21,7 +21,7 @@ message AddResponse {
 }
 
 message RemoveRequest {
-    types.H256 hash = 1;
+    repeated types.H256 hash = 1;
 }
 
 enum RemoveResult {
@@ -107,12 +107,22 @@ message SetReputationResponse {
     SetReputationResult result = 1;
 }
 
+message GetSortedRequest{
+    types.H160 entrypoint = 1;
+    uint64 max_limit = 2;
+}
+
+message GetSortedResponse{
+    repeated types.UserOperation user_operations = 1;
+}
+
 service UoPool {
     rpc Add(AddRequest) returns (AddResponse);
     rpc Remove(RemoveRequest) returns (RemoveResponse);
     rpc GetChainId(google.protobuf.Empty) returns (GetChainIdResponse);
     rpc GetSupportedEntryPoints(google.protobuf.Empty) returns (GetSupportedEntryPointsResponse);
     rpc EstimateUserOperationGas(EstimateUserOperationGasRequest) returns (EstimateUserOperationGasResponse);
+    rpc GetSortedUserOperations(GetSortedRequest) returns (GetSortedResponse);
 
     // debug
     rpc GetAll(GetAllRequest) returns (GetAllResponse);

--- a/src/proto/uopool/uopool.proto
+++ b/src/proto/uopool/uopool.proto
@@ -108,7 +108,7 @@ message SetReputationResponse {
 }
 
 message GetSortedRequest{
-    types.H160 entrypoint = 1;
+    types.H160 entry_point = 1;
 }
 
 message GetSortedResponse{

--- a/src/types/reputation.rs
+++ b/src/types/reputation.rs
@@ -13,6 +13,9 @@ pub const BAN_SLACK: u64 = 50;
 const ENTITY_BANNED_ERROR_CODE: i32 = -32504;
 const STAKE_TOO_LOW_ERROR_CODE: i32 = -32505;
 
+// If the paymaster is throttle, maximum amount in one bundle is 1.
+pub const THROTTLED_MAX_INCLUDE: u64 = 1;
+
 pub type ReputationError = ErrorObject<'static>;
 
 #[derive(Clone, Copy, Educe, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/uopool/database_mempool.rs
+++ b/src/uopool/database_mempool.rs
@@ -164,7 +164,7 @@ impl<E: EnvironmentKind> Mempool for DatabaseMempool<E> {
         }
     }
 
-    fn get_sorted(&self, max_limit: u64) -> Result<Self::UserOperations, DBError> {
+    fn get_sorted(&self) -> Result<Self::UserOperations, DBError> {
         self.env
             .tx()
             .and_then(|tx| {
@@ -175,7 +175,6 @@ impl<E: EnvironmentKind> Mempool for DatabaseMempool<E> {
                     .collect::<Result<Vec<_>, _>>()?;
                 user_ops
                     .sort_by(|a, b| b.max_priority_fee_per_gas.cmp(&a.max_priority_fee_per_gas));
-                user_ops.truncate(max_limit as usize);
                 Ok(user_ops)
             })
             .map_err(DBError::DBInternalError)

--- a/src/uopool/database_mempool.rs
+++ b/src/uopool/database_mempool.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{Display, Pointer},
-    path::PathBuf,
-};
+use std::{fmt::Display, path::PathBuf};
 
 use super::Mempool;
 use crate::types::{
@@ -93,7 +90,7 @@ impl From<Error> for DBError {
 
 impl Display for DBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/uopool/memory_mempool.rs
+++ b/src/uopool/memory_mempool.rs
@@ -86,6 +86,14 @@ impl Mempool for MemoryMempool {
         Ok(())
     }
 
+    fn get_sorted(&self, max_limit: u64) -> anyhow::Result<Self::UserOperations> {
+        let mut user_operations: Vec<UserOperation> =
+            self.user_operations.values().into_iter().cloned().collect();
+        user_operations.sort_by(|a, b| b.max_priority_fee_per_gas.cmp(&a.max_priority_fee_per_gas));
+        user_operations.truncate(max_limit as usize);
+        Ok(user_operations)
+    }
+
     #[cfg(debug_assertions)]
     fn get_all(&self) -> Self::UserOperations {
         self.user_operations.values().cloned().collect()

--- a/src/uopool/memory_mempool.rs
+++ b/src/uopool/memory_mempool.rs
@@ -88,7 +88,7 @@ impl Mempool for MemoryMempool {
 
     fn get_sorted(&self) -> anyhow::Result<Self::UserOperations> {
         let mut user_operations: Vec<UserOperation> =
-            self.user_operations.values().into_iter().cloned().collect();
+            self.user_operations.values().cloned().collect();
         user_operations.sort_by(|a, b| b.max_priority_fee_per_gas.cmp(&a.max_priority_fee_per_gas));
         Ok(user_operations)
     }

--- a/src/uopool/memory_mempool.rs
+++ b/src/uopool/memory_mempool.rs
@@ -86,11 +86,10 @@ impl Mempool for MemoryMempool {
         Ok(())
     }
 
-    fn get_sorted(&self, max_limit: u64) -> anyhow::Result<Self::UserOperations> {
+    fn get_sorted(&self) -> anyhow::Result<Self::UserOperations> {
         let mut user_operations: Vec<UserOperation> =
             self.user_operations.values().into_iter().cloned().collect();
         user_operations.sort_by(|a, b| b.max_priority_fee_per_gas.cmp(&a.max_priority_fee_per_gas));
-        user_operations.truncate(max_limit as usize);
         Ok(user_operations)
     }
 

--- a/src/uopool/memory_mempool.rs
+++ b/src/uopool/memory_mempool.rs
@@ -109,88 +109,11 @@ impl Mempool for MemoryMempool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethers::types::{H256, U256};
-
+    use crate::uopool::utils::tests::mempool_test_case;
     #[allow(clippy::unit_cmp)]
     #[tokio::test]
     async fn memory_mempool() {
-        let entry_point = Address::random();
-        let chain_id = U256::from(5);
-        let senders = vec![Address::random(), Address::random(), Address::random()];
-
-        let mut mempool = MemoryMempool::default();
-        let mut user_operation: UserOperation;
-        let mut user_operation_hash: UserOperationHash = Default::default();
-
-        for i in 0..2 {
-            user_operation = UserOperation {
-                sender: senders[0],
-                nonce: U256::from(i),
-                ..UserOperation::random()
-            };
-            user_operation_hash = mempool
-                .add(user_operation.clone(), &entry_point, &chain_id)
-                .unwrap();
-
-            assert_eq!(
-                mempool.get(&user_operation_hash).unwrap().unwrap(),
-                user_operation
-            );
-
-            user_operation = UserOperation {
-                sender: senders[1],
-                nonce: U256::from(i),
-                ..UserOperation::random()
-            };
-
-            user_operation_hash = mempool
-                .add(user_operation.clone(), &entry_point, &chain_id)
-                .unwrap();
-
-            assert_eq!(
-                mempool.get(&user_operation_hash).unwrap().unwrap(),
-                user_operation
-            );
-        }
-
-        for i in 0..3 {
-            user_operation = UserOperation {
-                sender: senders[2],
-                nonce: U256::from(i),
-                ..UserOperation::random()
-            };
-
-            user_operation_hash = mempool
-                .add(user_operation.clone(), &entry_point, &chain_id)
-                .unwrap();
-
-            assert_eq!(
-                mempool.get(&user_operation_hash).unwrap().unwrap(),
-                user_operation
-            );
-        }
-
-        assert_eq!(mempool.get_all().len(), 7);
-        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 2);
-        assert_eq!(mempool.get_all_by_sender(&senders[1]).len(), 2);
-        assert_eq!(mempool.get_all_by_sender(&senders[2]).len(), 3);
-
-        assert_eq!(mempool.remove(&user_operation_hash).unwrap(), ());
-        assert_eq!(
-            mempool
-                .remove(&H256::random().into())
-                .unwrap_err()
-                .to_string(),
-            anyhow::anyhow!("User operation not found").to_string()
-        );
-
-        assert_eq!(mempool.get_all().len(), 6);
-        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 2);
-        assert_eq!(mempool.get_all_by_sender(&senders[2]).len(), 2);
-
-        assert_eq!(mempool.clear(), ());
-
-        assert_eq!(mempool.get_all().len(), 0);
-        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 0);
+        let mempool = MemoryMempool::default();
+        mempool_test_case(mempool, "User operation not found");
     }
 }

--- a/src/uopool/mod.rs
+++ b/src/uopool/mod.rs
@@ -31,6 +31,7 @@ pub mod memory_mempool;
 pub mod memory_reputation;
 pub mod server;
 pub mod services;
+pub mod utils;
 
 pub type MempoolId = H256;
 

--- a/src/uopool/mod.rs
+++ b/src/uopool/mod.rs
@@ -59,6 +59,7 @@ pub trait Mempool: Debug {
     fn get_all_by_sender(&self, sender: &Address) -> Self::UserOperations;
     fn get_number_by_sender(&self, sender: &Address) -> usize;
     fn remove(&mut self, user_operation_hash: &UserOperationHash) -> Result<(), Self::Error>;
+    fn get_sorted(&self, max_limit: u64) -> Result<Self::UserOperations, Self::Error>;
 
     #[cfg(debug_assertions)]
     fn get_all(&self) -> Self::UserOperations;

--- a/src/uopool/mod.rs
+++ b/src/uopool/mod.rs
@@ -60,7 +60,8 @@ pub trait Mempool: Debug {
     fn get_all_by_sender(&self, sender: &Address) -> Self::UserOperations;
     fn get_number_by_sender(&self, sender: &Address) -> usize;
     fn remove(&mut self, user_operation_hash: &UserOperationHash) -> Result<(), Self::Error>;
-    fn get_sorted(&self, max_limit: u64) -> Result<Self::UserOperations, Self::Error>;
+    // Get UserOperations sorted by max_priority_fee_per_gas without dup sender
+    fn get_sorted(&self) -> Result<Self::UserOperations, Self::Error>;
 
     #[cfg(debug_assertions)]
     fn get_all(&self) -> Self::UserOperations;

--- a/src/uopool/services/uopool.rs
+++ b/src/uopool/services/uopool.rs
@@ -311,16 +311,10 @@ where
                     let reputation_lock = self.reputations.read();
                     match reputation_lock.get(&mempool_id) {
                         Some(reputation_entries) => {
-                            let paymaster_status = if let Some(paymaster) = paymaster_opt {
-                                reputation_entries.get_status(&paymaster)
-                            } else {
-                                ReputationStatus::OK
-                            };
-                            let deployer_status = if let Some(factory) = factory_opt {
-                                reputation_entries.get_status(&factory)
-                            } else {
-                                ReputationStatus::OK
-                            };
+                            let paymaster_status =
+                                reputation_entries.get_status_from_bytes(&uo.paymaster_and_data);
+                            let deployer_status =
+                                reputation_entries.get_status_from_bytes(&uo.init_code);
                             (paymaster_status, deployer_status)
                         }
                         None => {

--- a/src/uopool/services/uopool.rs
+++ b/src/uopool/services/uopool.rs
@@ -13,8 +13,9 @@ use crate::{
             EstimateUserOperationGasRequest, EstimateUserOperationGasResponse,
             EstimateUserOperationGasResult, GetAllReputationRequest, GetAllReputationResponse,
             GetAllReputationResult, GetAllRequest, GetAllResponse, GetAllResult,
-            GetChainIdResponse, GetSupportedEntryPointsResponse, RemoveRequest, RemoveResponse,
-            SetReputationRequest, SetReputationResponse, SetReputationResult,
+            GetChainIdResponse, GetSortedRequest, GetSortedResponse,
+            GetSupportedEntryPointsResponse, RemoveRequest, RemoveResponse, SetReputationRequest,
+            SetReputationResponse, SetReputationResult,
         },
         MempoolBox, MempoolId, ReputationBox,
     },
@@ -254,6 +255,13 @@ where
         }
 
         Err(tonic::Status::invalid_argument("missing user operation"))
+    }
+
+    async fn get_sorted_user_operations(
+        &self,
+        request: tonic::Request<GetSortedRequest>,
+    ) -> Result<Response<GetSortedResponse>, tonic::Status> {
+        todo!()
     }
 
     #[cfg(debug_assertions)]

--- a/src/uopool/services/uopool.rs
+++ b/src/uopool/services/uopool.rs
@@ -272,7 +272,7 @@ where
     ) -> Result<Response<GetSortedResponse>, tonic::Status> {
         let req = request.into_inner();
         if let GetSortedRequest {
-            entrypoint: Some(entry_point),
+            entry_point: Some(entry_point),
         } = req
         {
             let entry_point: Address = entry_point

--- a/src/uopool/utils.rs
+++ b/src/uopool/utils.rs
@@ -1,0 +1,94 @@
+#[cfg(test)]
+pub mod tests {
+    use std::fmt::Debug;
+
+    use ethers::types::{Address, H256, U256};
+
+    use crate::{
+        types::user_operation::{UserOperation, UserOperationHash},
+        uopool::Mempool,
+    };
+
+    pub fn mempool_test_case<T>(mut mempool: T, not_found_error_message: &str)
+    where
+        T: Mempool<UserOperations = Vec<UserOperation>> + Debug,
+        T::Error: Debug + ToString,
+    {
+        let entry_point = Address::random();
+        let chain_id = U256::from(5);
+        let senders = vec![Address::random(), Address::random(), Address::random()];
+
+        let mut user_operation: UserOperation;
+        let mut user_operation_hash: UserOperationHash = Default::default();
+        for i in 0..2 {
+            user_operation = UserOperation {
+                sender: senders[0],
+                nonce: U256::from(i),
+                ..UserOperation::random()
+            };
+            user_operation_hash = mempool
+                .add(user_operation.clone(), &entry_point, &chain_id)
+                .unwrap();
+
+            assert_eq!(
+                mempool.get(&user_operation_hash).unwrap().unwrap(),
+                user_operation
+            );
+
+            user_operation = UserOperation {
+                sender: senders[1],
+                nonce: U256::from(i),
+                ..UserOperation::random()
+            };
+
+            user_operation_hash = mempool
+                .add(user_operation.clone(), &entry_point, &chain_id)
+                .unwrap();
+
+            assert_eq!(
+                mempool.get(&user_operation_hash).unwrap().unwrap(),
+                user_operation
+            );
+        }
+
+        for i in 0..3 {
+            user_operation = UserOperation {
+                sender: senders[2],
+                nonce: U256::from(i),
+                ..UserOperation::random()
+            };
+
+            user_operation_hash = mempool
+                .add(user_operation.clone(), &entry_point, &chain_id)
+                .unwrap();
+
+            assert_eq!(
+                mempool.get(&user_operation_hash).unwrap().unwrap(),
+                user_operation
+            );
+        }
+
+        assert_eq!(mempool.get_all().len(), 7);
+        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 2);
+        assert_eq!(mempool.get_all_by_sender(&senders[1]).len(), 2);
+        assert_eq!(mempool.get_all_by_sender(&senders[2]).len(), 3);
+
+        assert_eq!(mempool.remove(&user_operation_hash).unwrap(), ());
+        assert_eq!(
+            mempool
+                .remove(&H256::random().into())
+                .unwrap_err()
+                .to_string(),
+            not_found_error_message
+        );
+
+        assert_eq!(mempool.get_all().len(), 6);
+        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 2);
+        assert_eq!(mempool.get_all_by_sender(&senders[2]).len(), 2);
+
+        assert_eq!(mempool.clear(), ());
+
+        assert_eq!(mempool.get_all().len(), 0);
+        assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 0);
+    }
+}

--- a/src/uopool/utils.rs
+++ b/src/uopool/utils.rs
@@ -1,3 +1,13 @@
+use ethers::types::{Address, Bytes};
+
+// Try to get the address from first 20 bytes. Return None if length of bytes < 20.
+pub fn get_addr(bytes: &Bytes) -> Option<Address> {
+    if bytes.len() >= 20 {
+        Some(Address::from_slice(&bytes[0..20]))
+    } else {
+        None
+    }
+}
 #[cfg(test)]
 pub mod tests {
     use std::fmt::Debug;

--- a/src/uopool/utils.rs
+++ b/src/uopool/utils.rs
@@ -90,5 +90,29 @@ pub mod tests {
 
         assert_eq!(mempool.get_all().len(), 0);
         assert_eq!(mempool.get_all_by_sender(&senders[0]).len(), 0);
+
+        for i in 0..3 {
+            user_operation = UserOperation {
+                sender: senders[2],
+                nonce: U256::from(i),
+                max_priority_fee_per_gas: U256::from(i + 1),
+                ..UserOperation::random()
+            };
+
+            user_operation_hash = mempool
+                .add(user_operation.clone(), &entry_point, &chain_id)
+                .unwrap();
+        }
+
+        let sorted = mempool.get_sorted(2).unwrap();
+        assert_eq!(sorted[0].max_priority_fee_per_gas, U256::from(3));
+        assert_eq!(sorted[1].max_priority_fee_per_gas, U256::from(2));
+        assert_eq!(sorted.len(), 2);
+
+        let sorted = mempool.get_sorted(5).unwrap();
+        assert_eq!(sorted[0].max_priority_fee_per_gas, U256::from(3));
+        assert_eq!(sorted[1].max_priority_fee_per_gas, U256::from(2));
+        assert_eq!(sorted[2].max_priority_fee_per_gas, U256::from(1));
+        assert_eq!(sorted.len(), 3);
     }
 }

--- a/src/uopool/utils.rs
+++ b/src/uopool/utils.rs
@@ -104,12 +104,7 @@ pub mod tests {
                 .unwrap();
         }
 
-        let sorted = mempool.get_sorted(2).unwrap();
-        assert_eq!(sorted[0].max_priority_fee_per_gas, U256::from(3));
-        assert_eq!(sorted[1].max_priority_fee_per_gas, U256::from(2));
-        assert_eq!(sorted.len(), 2);
-
-        let sorted = mempool.get_sorted(5).unwrap();
+        let sorted = mempool.get_sorted().unwrap();
         assert_eq!(sorted[0].max_priority_fee_per_gas, U256::from(3));
         assert_eq!(sorted[1].max_priority_fee_per_gas, U256::from(2));
         assert_eq!(sorted[2].max_priority_fee_per_gas, U256::from(1));

--- a/src/uopool/utils.rs
+++ b/src/uopool/utils.rs
@@ -99,7 +99,7 @@ pub mod tests {
                 ..UserOperation::random()
             };
 
-            user_operation_hash = mempool
+            mempool
                 .add(user_operation.clone(), &entry_point, &chain_id)
                 .unwrap();
         }


### PR DESCRIPTION
Enable bundle function in #10 

There is one leftover in the pr.
1. When the user operations are submitted to the client, the bundler needs to observe the transactions are finalized in the blockchain and send a remove request to the pool, and update the reputation accordingly.

Tests are also missing now.