### PR TITLE
Fix execution revert case in estimate gas api

### DIFF
--- a/src/types/simulation.rs
+++ b/src/types/simulation.rs
@@ -1,5 +1,5 @@
 use ethers::types::{Address, U256};
-use jsonrpsee::types::ErrorObject;
+use jsonrpsee::types::{error::ErrorCode, ErrorObject};
 use lazy_static::lazy_static;
 use std::collections::HashSet;
 
@@ -81,7 +81,7 @@ impl From<SimulateValidationError> for SimulationError {
                 SimulationError::owned(OPCODE_VALIDATION_ERROR_CODE, message, None::<bool>)
             }
             SimulateValidationError::UnknownError { error } => {
-                SimulationError::owned(SIMULATE_VALIDATION_ERROR_CODE, error, None::<bool>)
+                SimulationError::owned(ErrorCode::InternalError.code(), error, None::<bool>)
             }
         }
     }

--- a/src/types/simulation.rs
+++ b/src/types/simulation.rs
@@ -1,8 +1,5 @@
-use ethers::{
-    providers::Middleware,
-    types::{Address, U256},
-};
-use jsonrpsee::types::{error::ErrorCode, ErrorObject};
+use ethers::types::{Address, U256};
+use jsonrpsee::types::ErrorObject;
 use lazy_static::lazy_static;
 use std::collections::HashSet;
 
@@ -52,18 +49,17 @@ pub struct StakeInfo {
 }
 
 #[derive(Debug)]
-pub enum SimulateValidationError<M: Middleware> {
+pub enum SimulateValidationError {
     UserOperationRejected { message: String },
     OpcodeValidation { entity: String, opcode: String },
     UserOperationExecution { message: String },
     StorageAccessValidation { slot: String },
     CallStackValidation { message: String },
-    Middleware(M::Error),
     UnknownError { error: String },
 }
 
-impl<M: Middleware> From<SimulateValidationError<M>> for SimulationError {
-    fn from(error: SimulateValidationError<M>) -> Self {
+impl From<SimulateValidationError> for SimulationError {
+    fn from(error: SimulateValidationError) -> Self {
         match error {
             SimulateValidationError::UserOperationRejected { message } => {
                 SimulationError::owned(SIMULATE_VALIDATION_ERROR_CODE, message, None::<bool>)
@@ -83,9 +79,6 @@ impl<M: Middleware> From<SimulateValidationError<M>> for SimulationError {
             ),
             SimulateValidationError::CallStackValidation { message } => {
                 SimulationError::owned(OPCODE_VALIDATION_ERROR_CODE, message, None::<bool>)
-            }
-            SimulateValidationError::Middleware(_) => {
-                SimulationError::from(ErrorCode::InternalError)
             }
             SimulateValidationError::UnknownError { error } => {
                 SimulationError::owned(SIMULATE_VALIDATION_ERROR_CODE, error, None::<bool>)

--- a/src/uopool/services/simulation.rs
+++ b/src/uopool/services/simulation.rs
@@ -29,7 +29,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         &self,
         user_operation: &UserOperation,
         entry_point: &Address,
-    ) -> Result<SimulateValidationResult, SimulateValidationError<M>> {
+    ) -> Result<SimulateValidationResult, SimulateValidationError> {
         let mempool_id = mempool_id(entry_point, &self.chain_id);
 
         if let Some(entry_point) = self.entry_points.get(&mempool_id) {
@@ -39,9 +39,6 @@ impl<M: Middleware + 'static> UoPoolService<M> {
             {
                 Ok(simulate_validation_result) => Ok(simulate_validation_result),
                 Err(entry_point_error) => match entry_point_error {
-                    EntryPointErr::MiddlewareErr(middleware_error) => {
-                        Err(SimulateValidationError::Middleware(middleware_error))
-                    }
                     EntryPointErr::FailedOp(failed_op) => {
                         Err(SimulateValidationError::UserOperationRejected {
                             message: format!("{failed_op}"),
@@ -63,7 +60,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         &self,
         user_operation: &UserOperation,
         entry_point: &Address,
-    ) -> Result<GethTrace, SimulateValidationError<M>> {
+    ) -> Result<GethTrace, SimulateValidationError> {
         let mempool_id = mempool_id(entry_point, &self.chain_id);
 
         if let Some(entry_point) = self.entry_points.get(&mempool_id) {
@@ -73,9 +70,6 @@ impl<M: Middleware + 'static> UoPoolService<M> {
             {
                 Ok(geth_trace) => Ok(geth_trace),
                 Err(entry_point_error) => match entry_point_error {
-                    EntryPointErr::MiddlewareErr(middleware_error) => {
-                        Err(SimulateValidationError::Middleware(middleware_error))
-                    }
                     EntryPointErr::FailedOp(failed_op) => {
                         Err(SimulateValidationError::UserOperationRejected {
                             message: format!("{failed_op}"),
@@ -144,7 +138,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         };
     }
 
-    fn forbidden_opcodes(&self, trace: &JsTracerFrame) -> Result<(), SimulateValidationError<M>> {
+    fn forbidden_opcodes(&self, trace: &JsTracerFrame) -> Result<(), SimulateValidationError> {
         for (index, _) in LEVEL_TO_ENTITY.iter().enumerate() {
             if let Some(level) = trace.number_levels.get(index) {
                 for opcode in level.opcodes.keys() {
@@ -204,7 +198,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         address: &Address,
         slot: &String,
         slots_by_entity: &HashMap<Address, HashSet<Bytes>>,
-    ) -> Result<bool, SimulateValidationError<M>> {
+    ) -> Result<bool, SimulateValidationError> {
         if *slot == address.to_string() {
             return Ok(true);
         }
@@ -237,7 +231,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         entry_point: &Address,
         stake_info_by_entity: &[StakeInfo; NUMBER_LEVELS],
         trace: &JsTracerFrame,
-    ) -> Result<(), SimulateValidationError<M>> {
+    ) -> Result<(), SimulateValidationError> {
         let mut slots_by_entity = HashMap::new();
         self.parse_slots(
             trace.keccak.clone(),
@@ -301,7 +295,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         &self,
         trace: &JsTracerFrame,
         calls: &mut Vec<CallEntry>,
-    ) -> Result<(), SimulateValidationError<M>> {
+    ) -> Result<(), SimulateValidationError> {
         let mut stack: Vec<Call> = vec![];
 
         for call in trace.calls.iter() {
@@ -364,7 +358,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         entry_point: &Address,
         stake_info_by_entity: &[StakeInfo; NUMBER_LEVELS],
         trace: &JsTracerFrame,
-    ) -> Result<(), SimulateValidationError<M>> {
+    ) -> Result<(), SimulateValidationError> {
         let mut calls: Vec<CallEntry> = vec![];
         self.parse_call_stack(trace, &mut calls)?;
 
@@ -413,7 +407,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
         &self,
         user_operation: &UserOperation,
         entry_point: &Address,
-    ) -> Result<SimulateValidationResult, SimulateValidationError<M>> {
+    ) -> Result<SimulateValidationResult, SimulateValidationError> {
         let simulate_validation_result = self
             .simulate_validation(user_operation, entry_point)
             .await?;

--- a/src/uopool/services/uopool.rs
+++ b/src/uopool/services/uopool.rs
@@ -85,7 +85,7 @@ impl<M: Middleware + 'static> UoPoolService<M> {
 #[async_trait]
 impl<M: Middleware + 'static> UoPool for UoPoolService<M>
 where
-    EntryPointErr<M>: From<<M as Middleware>::Error>,
+    EntryPointErr: From<<M as Middleware>::Error>,
 {
     async fn add(
         &self,
@@ -221,7 +221,7 @@ where
                             Err(error) => {
                                 res.set_result(EstimateUserOperationGasResult::NotEstimated);
                                 res.data = serde_json::to_string(&SimulationError::from(
-                                    SimulateValidationError::<M>::UnknownError {
+                                    SimulateValidationError::UnknownError {
                                         error: format!("{error:?}"),
                                     },
                                 ))


### PR DESCRIPTION
Fix https://github.com/Vid201/aa-bundler/issues/84

Middleware error should be all internal errors which bundler user should not know that. I remove the trait bound on the error type. Be more concrete on the error.