### PR TITLE
chore: remove user operations from mempool

### DIFF
--- a/bin/bundler.rs
+++ b/bin/bundler.rs
@@ -114,6 +114,7 @@ fn main() -> Result<()> {
                     opt.bundler_opts.beneficiary,
                     uopool_grpc_client.clone(),
                     opt.entry_points,
+                    chain_id,
                     opt.eth_client_address.clone(),
                 );
                 info!("Starting bundler manager");

--- a/src/proto/uopool/uopool.proto
+++ b/src/proto/uopool/uopool.proto
@@ -21,7 +21,8 @@ message AddResponse {
 }
 
 message RemoveRequest {
-    repeated types.H256 hash = 1;
+    repeated types.H256 hashes = 1;
+    types.H160 ep = 2;
 }
 
 enum RemoveResult {


### PR DESCRIPTION
This PR does the following:

- implements removing user operations from memool (gRPC)
- skip waiting for transaction receipt - we can add that later, tests are running very long if we wait for receipt (and it's not needed for tests)
- fix some gas issues when sending bundle as tx (tx reverted due to running out of gas)